### PR TITLE
Limit iterations by number of seconds

### DIFF
--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -594,7 +594,7 @@ static void DeflateDynamicBlock(const ZopfliOptions* options, ZopfliBlockState *
 
   ZopfliInitLZ77Store(&store);
 
-  ZopfliLZ77Optimal(s, in, instart, inend, &store);
+  ZopfliLZ77Optimal(s, in, instart, inend, &store, s->blockiterationlimit);
 
   /* For small block, encoding with fixed tree can be smaller. For large block,
   don't bother doing this expensive test, dynamic tree will be better.*/
@@ -675,7 +675,9 @@ static void DeflateBlock(const ZopfliOptions* options,
                          int btype, int final,
                          const unsigned char* in, size_t instart, size_t inend,
                          unsigned char* bp,
-                         unsigned char** out, size_t* outsize) {
+                         unsigned char** out, size_t* outsize,
+                         double blockiterationlimit) {
+
   if (btype == 0) {
     DeflateNonCompressedBlock(
         options, final, in, instart, inend, bp, out, outsize);
@@ -684,6 +686,7 @@ static void DeflateBlock(const ZopfliOptions* options,
     s.options = options;
     s.blockstart = instart;
     s.blockend = inend;
+    s.blockiterationlimit = blockiterationlimit;
 
 #ifdef ZOPFLI_LONGEST_MATCH_CACHE
     s.lmc = (ZopfliLongestMatchCache*)malloc(sizeof(ZopfliLongestMatchCache));
@@ -731,8 +734,10 @@ static void DeflateSplittingFirst(const ZopfliOptions* options,
   for (i = 0; i <= npoints; i++) {
     size_t start = i == 0 ? instart : splitpoints[i - 1];
     size_t end = i == npoints ? inend : splitpoints[i];
+    double blockiterationlimit = options->iterationlimitseconds * (end-start) / (inend-instart);
+
     DeflateBlock(options, btype, i == npoints && final, in, start, end,
-                 bp, out, outsize);
+                 bp, out, outsize, blockiterationlimit);
   }
 
   free(splitpoints);
@@ -771,7 +776,7 @@ static void DeflateSplittingLast(const ZopfliOptions* options,
   s.blockend = inend;
 
   if (btype == 2) {
-    ZopfliLZ77Optimal(&s, in, instart, inend, &store);
+    ZopfliLZ77Optimal(&s, in, instart, inend, &store, options->iterationlimitseconds);
   } else {
     assert (btype == 1);
     ZopfliLZ77OptimalFixed(&s, in, instart, inend, &store);
@@ -819,7 +824,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
                             bp, out, outsize);
     }
   } else {
-    DeflateBlock(options, btype, final, in, instart, inend, bp, out, outsize);
+    DeflateBlock(options, btype, final, in, instart, inend, bp, out, outsize, options->iterationlimitseconds);
   }
 }
 

--- a/src/zopfli/lz77.h
+++ b/src/zopfli/lz77.h
@@ -70,6 +70,10 @@ typedef struct ZopfliBlockState {
   /* The start (inclusive) and end (not inclusive) of the current block. */
   size_t blockstart;
   size_t blockend;
+
+  /* if non-0, CPU time limit for iterations on this block
+     (proportional slice of overall iteration time limit) */
+  double blockiterationlimit;
 } ZopfliBlockState;
 
 /*

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -447,7 +447,8 @@ static double LZ77OptimalRun(ZopfliBlockState* s,
 
 void ZopfliLZ77Optimal(ZopfliBlockState *s,
                        const unsigned char* in, size_t instart, size_t inend,
-                       ZopfliLZ77Store* store) {
+                       ZopfliLZ77Store* store,
+                       double iterationlimitseconds) {
   /* Dist to get to here with smallest cost. */
   size_t blocksize = inend - instart;
   unsigned short* length_array =
@@ -480,7 +481,7 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
 
 #ifdef CLOCKS_PER_SEC
   clock_t start;
-  if (s->options->iterationlimitseconds > 0) {
+  if (iterationlimitseconds > 0) {
     start = clock();
   }
 #endif
@@ -523,11 +524,11 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
     lastcost = cost;
 
 #ifdef CLOCKS_PER_SEC
-    if (s->options->iterationlimitseconds > 0) {
+    if (iterationlimitseconds > 0) {
       double diff_sec = (double)(clock()-start)/CLOCKS_PER_SEC;
-      if (diff_sec >= s->options->iterationlimitseconds) {
+      if (diff_sec >= iterationlimitseconds) {
         if (s->options->verbose_more) {
-          fprintf(stderr, "Stopped after %d iterations due to time limit\n", i);
+          fprintf(stderr, "Stopped after %d iterations due to time limit %f\n", i, diff_sec);
         }
         break;
       }

--- a/src/zopfli/squeeze.c
+++ b/src/zopfli/squeeze.c
@@ -464,6 +464,9 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
   /* Try randomizing the costs a bit once the size stabilizes. */
   RanState ran_state;
   int lastrandomstep = -1;
+#ifdef CLOCKS_PER_SEC
+  clock_t start;
+#endif
 
   if (!length_array) exit(-1); /* Allocation failed. */
 
@@ -480,7 +483,6 @@ void ZopfliLZ77Optimal(ZopfliBlockState *s,
 
 
 #ifdef CLOCKS_PER_SEC
-  clock_t start;
   if (iterationlimitseconds > 0) {
     start = clock();
   }

--- a/src/zopfli/squeeze.h
+++ b/src/zopfli/squeeze.h
@@ -40,7 +40,8 @@ dictionary.
 */
 void ZopfliLZ77Optimal(ZopfliBlockState *s,
                        const unsigned char* in, size_t instart, size_t inend,
-                       ZopfliLZ77Store* store);
+                       ZopfliLZ77Store* store,
+                       double iterationlimitseconds);
 
 /*
 Does the same as ZopfliLZ77Optimal, but optimized for the fixed tree of the

--- a/src/zopfli/zopfli.h
+++ b/src/zopfli/zopfli.h
@@ -45,6 +45,13 @@ typedef struct ZopfliOptions {
   int numiterations;
 
   /*
+  Maximum number of seconds of CPU time to spend on iterations.
+  Iteration ends when the time is exceeded.
+  Default: 0 (no limit).
+  */
+  double iterationlimitseconds;
+
+  /*
   If true, splits the data in multiple deflate blocks with optimal choice
   for the block boundaries. Block splitting gives better compression. Default:
   true (1).

--- a/src/zopflipng/zopflipng_bin.cc
+++ b/src/zopflipng/zopflipng_bin.cc
@@ -93,6 +93,8 @@ void ShowHelp() {
          "--iterations=[number]: number of iterations, more iterations makes it"
          " slower but provides slightly better compression. Default: 15 for"
          " small files, 5 for large files.\n"
+         "--timelimit=[cpuseconds]: maximum amount of CPU time to spend "
+         " iterating. Default: 0 (unlimited)\n"
          "--splitting=[0-3]: block split strategy:"
          " 0=none, 1=first, 2=last, 3=try both and take the best\n"
          "--filters=[types]: filter strategies to try:\n"
@@ -190,6 +192,9 @@ int main(int argc, char *argv[]) {
         if (num < 1) num = 1;
         png_options.num_iterations = num;
         png_options.num_iterations_large = num;
+      } else if (name == "--timelimit") {
+          if (num < 0) num = 0;
+          png_options.iterations_time_limit = num;
       } else if (name == "--splitting") {
         if (num < 0 || num > 3) num = 1;
         png_options.block_split_strategy = num;

--- a/src/zopflipng/zopflipng_lib.cc
+++ b/src/zopflipng/zopflipng_lib.cc
@@ -54,6 +54,8 @@ unsigned CustomPNGDeflate(unsigned char** out, size_t* outsize,
   options.numiterations = insize < 200000
       ? png_options->num_iterations : png_options->num_iterations_large;
 
+  options.iterationlimitseconds = png_options->iterations_time_limit;
+
   if (png_options->block_split_strategy == 3) {
     // Try both block splitting first and last.
     unsigned char* out2 = 0;

--- a/src/zopflipng/zopflipng_lib.h
+++ b/src/zopflipng/zopflipng_lib.h
@@ -116,6 +116,9 @@ struct ZopfliPNGOptions {
   // Zopfli number of iterations on large images
   int num_iterations_large;
 
+  // Time to spend on iterations (in seconds, 0 = no limit)
+  int iterations_time_limit;
+
   // 0=none, 1=first, 2=last, 3=both
   int block_split_strategy;
 };


### PR DESCRIPTION
"Iteration" speed depends on the image, so it's hard to automatically find a value that will guarantee that image finishes optimizing before the user loses patience.

This is a change I've made for ImageOptim to limit processing *time* by checking progress against used CPU time.