### PR TITLE
Fix RGB value of first encountered transparent pixel

### DIFF
--- a/src/zopflipng/zopflipng_lib.cc
+++ b/src/zopflipng/zopflipng_lib.cc
@@ -133,6 +133,7 @@ void LossyOptimizeTransparent(lodepng::State* inputstate, unsigned char* image,
         r = image[i * 4 + 0];
         g = image[i * 4 + 1];
         b = image[i * 4 + 2];
+        break;
       }
     }
   }


### PR DESCRIPTION
The comment suggest to use first encountered transparent pixel, which I think is the right way, but the code is using last encountered transparent pixel.