### PR TITLE
Various fixes

### DIFF
--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -31,6 +31,10 @@ void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
   lmc->dist = (unsigned short*)malloc(sizeof(unsigned short) * blocksize);
   /* Rather large amount of memory. */
   lmc->sublen = (unsigned char*)malloc(ZOPFLI_CACHE_LENGTH * 3 * blocksize);
+  if(lmc->sublen == NULL) {
+    fprintf(stderr,"Error: Out of memory. Tried allocating %lu bytes of memory.\n",(unsigned long)(ZOPFLI_CACHE_LENGTH * 3 * blocksize));
+    exit (EXIT_FAILURE);
+  }
 
   /* length > 0 and dist 0 is invalid combination, which indicates on purpose
   that this cache value is not filled in yet. */

--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -844,6 +844,7 @@ void ZopfliDeflatePart(const ZopfliOptions* options, int btype, int final,
 void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
                    const unsigned char* in, size_t insize,
                    unsigned char* bp, unsigned char** out, size_t* outsize) {
+ size_t offset = *outsize;
 #if ZOPFLI_MASTER_BLOCK_SIZE == 0
   ZopfliDeflatePart(options, btype, final, in, 0, insize, bp, out, outsize);
 #else
@@ -860,7 +861,7 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
   if (options->verbose) {
     fprintf(stderr,
             "Original Size: %d, Deflate: %d, Compression: %f%% Removed\n",
-            (int)insize, (int)*outsize,
-            100.0 * (double)(insize - *outsize) / (double)insize);
+            (int)insize, (int)(*outsize - offset),
+            100.0 * (double)(insize - (*outsize - offset)) / (double)insize);
   }
 }

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -52,6 +52,10 @@ static void LoadFile(const char* filename,
 
   fseek(file , 0 , SEEK_END);
   *outsize = ftell(file);
+  if(*outsize > 2147483647) {
+    fprintf(stderr,"Files larger than 2GB are not supported.\n");
+    exit(EXIT_FAILURE);
+  }
   rewind(file);
 
   *out = (unsigned char*)malloc(*outsize);

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -33,6 +33,11 @@ decompressor.
 #include "gzip_container.h"
 #include "zlib_container.h"
 
+/* Windows workaround for stdout output. */
+#if _WIN32
+#include <fcntl.h>
+#endif
+
 /*
 Loads a file into a memory array.
 */
@@ -103,10 +108,17 @@ static void CompressFile(const ZopfliOptions* options,
     SaveFile(outfilename, out, outsize);
   } else {
     size_t i;
+/* Windows workaround for stdout output. */
+#if _WIN32
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
     for (i = 0; i < outsize; i++) {
       /* Works only if terminal does not convert newlines. */
       printf("%c", out[i]);
     }
+#if _WIN32
+    _setmode(_fileno(stdout), _O_TEXT);
+#endif
   }
 
   free(out);

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -71,6 +71,10 @@ Saves a file from a memory array, overwriting the file if it existed.
 static void SaveFile(const char* filename,
                      const unsigned char* in, size_t insize) {
   FILE* file = fopen(filename, "wb" );
+  if (file == NULL) {
+      fprintf(stderr,"Error: Cannot write to output file, terminating.\n");
+      exit (EXIT_FAILURE);
+  }
   assert(file);
   fwrite((char*)in, 1, insize, file);
   fclose(file);

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -184,7 +184,7 @@ int main(int argc, char* argv[]) {
   }
 
   if (options.numiterations < 1) {
-    fprintf(stderr, "Error: must have 1 or more iterations");
+    fprintf(stderr, "Error: must have 1 or more iterations\n");
     return 0;
   }
 


### PR DESCRIPTION
- Fix incorrect Deflate stream reporting when zlib or gz container is used - use offset to record outsize before compressing and then use that offset to properly display compressed stream size,
- Fix SIGSEGV when file can't be opened for writing binary ("wb") by displaying error message and exiting with EXIT_FAILURE. This will help person understand that he/she is working in read-only directory or forgot to sudo,
- Fix output to stdout on Windows to not convert new lines, instead output to terminal as binary (I'm not sure if changing back to text mode is necessary but did it just to be safe and not break terminal output after zopfli closes),
- Fix iterations error message not ending with new line separator making some terminals display command prompt at the end of this message when zopfli exist (for example Linux),
- Fix SIGSEGV when there is not enough memory to allocate cache, display error and exit instead.