### PR TITLE
Returning non-zero status in case of error in parameters

### DIFF
--- a/src/zopflipng/zopflipng_bin.cc
+++ b/src/zopflipng/zopflipng_bin.cc
@@ -136,7 +136,7 @@ void PrintResultSize(const char* label, size_t oldsize, size_t newsize) {
 int main(int argc, char *argv[]) {
   if (argc < 2) {
     ShowHelp();
-    return 0;
+    return 1;
   }
 
   ZopfliPNGOptions png_options;
@@ -171,7 +171,7 @@ int main(int argc, char *argv[]) {
           return 0;
         } else {
           printf("Unknown flag: %c\n", c);
-          return 0;
+          return 1;
         }
       }
     } else if (arg[0] == '-' && arg.size() > 1 && arg[1] == '-') {
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
         if (!correct) {
           printf("Error: keepchunks format must be like for example:\n"
                  " --keepchunks=gAMA,cHRM,sRGB,iCCP\n");
-          return 0;
+          return 1;
         }
       } else if (name == "--prefix") {
         use_prefix = true;
@@ -237,7 +237,7 @@ int main(int argc, char *argv[]) {
         return 0;
       } else {
         printf("Unknown flag: %s\n", name.c_str());
-        return 0;
+        return 1;
       }
     } else {
       files.push_back(argv[i]);
@@ -253,7 +253,7 @@ int main(int argc, char *argv[]) {
     } else {
       printf("Please provide one input and output filename\n\n");
       ShowHelp();
-      return 0;
+      return 1;
     }
   }
 


### PR DESCRIPTION
Knowing when something happened correctly and when an error occurred is important when using zopflipng in other scripts.

In special, if the help message is printed without passing `-h` or `--help`, it happened because of wrong or missing parameters, and should return a non-zero status. However, passing `-h` or `--help` will return 0.