### PR TITLE
Fix for _setmode usage

### DIFF
--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -112,17 +112,13 @@ static void CompressFile(const ZopfliOptions* options,
     SaveFile(outfilename, out, outsize);
   } else {
     size_t i;
-/* Windows workaround for stdout output. */
 #if _WIN32
+    /* Windows workaround for stdout output. */
     _setmode(_fileno(stdout), _O_BINARY);
 #endif
     for (i = 0; i < outsize; i++) {
-      /* Works only if terminal does not convert newlines. */
       printf("%c", out[i]);
     }
-#if _WIN32
-    _setmode(_fileno(stdout), _O_TEXT);
-#endif
   }
 
   free(out);


### PR DESCRIPTION
The previous fix didn't work for me. I suspect because it changed the state of the fd back to _O_TEXT without flushing the file beforehand, so when the end of the file was flushed to the _O_TEXT fd, it got the \r\n conversion again. As mentioned at the end of #56, I don't think it's necessary to change the stream back to _O_TEXT, so this just removes that call.

This also removes a redundant comment (the code should work regardless of new-line conversion now) and indents another comment.

Tested with MSYS2/mingw-w64 on Windows 8.1 with a few small text files and one larger binary file.