### PR TITLE
Properly specify prerequisites in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,53 @@
 CC = gcc
 CXX = g++
 
-CFLAGS = -W -Wall -Wextra -ansi -pedantic -lm -O2
+CFLAGS = -W -Wall -Wextra -ansi -pedantic -O2
 CXXFLAGS = -W -Wall -Wextra -ansi -pedantic -O2
+LDFLAGS = -lm
 
-ZOPFLILIB_SRC = src/zopfli/blocksplitter.c src/zopfli/cache.c\
-                src/zopfli/deflate.c src/zopfli/gzip_container.c\
+ZOPFLI_SRC := 	src/zopfli/blocksplitter.c src/zopfli/cache.c\
+		src/zopfli/deflate.c src/zopfli/gzip_container.c\
                 src/zopfli/hash.c src/zopfli/katajainen.c\
                 src/zopfli/lz77.c src/zopfli/squeeze.c\
                 src/zopfli/tree.c src/zopfli/util.c\
-                src/zopfli/zlib_container.c src/zopfli/zopfli_lib.c
-ZOPFLILIB_OBJ := $(patsubst src/zopfli/%.c,%.o,$(ZOPFLILIB_SRC))
-ZOPFLIBIN_SRC := src/zopfli/zopfli_bin.c
+                src/zopfli/zlib_container.c
+ZOPFLILIB_SRC := $(ZOPFLI_SRC) src/zopfli/zopfli_lib.c
+ZOPFLILIB_OBJ := $(addsuffix .lo,$(basename $(ZOPFLILIB_SRC)))
+ZOPFLIBIN_OBJ := $(addsuffix .o,$(basename $(ZOPFLILIB_SRC)))
 LODEPNG_SRC := src/zopflipng/lodepng/lodepng.cpp src/zopflipng/lodepng/lodepng_util.cpp
-ZOPFLIPNGLIB_SRC := src/zopflipng/zopflipng_lib.cc
-ZOPFLIPNGBIN_SRC := src/zopflipng/zopflipng_bin.cc
+ZOPFLIPNGLIB_SRC := src/zopflipng/zopflipng_lib.cc $(LODEPNG_SRC)
+ZOPFLIPNGLIB_OBJ := $(addsuffix .lo,$(basename $(ZOPFLIPNGLIB_SRC)))
+ZOPFLIPNGBIN_OBJ := $(addsuffix .o,$(basename $(ZOPFLIPNGLIB_SRC)))
 
-.PHONY: zopfli zopflipng
+.PHONY: clean all
+
+%.lo: %.c
+	$(CC) $(CFLAGS) -fPIC -c -o $@ $^
+
+%.lo: %.c?*
+	$(CXX) $(CXXFLAGS) -fPIC -c -o $@ $^
 
 # Zopfli binary
-zopfli:
-	$(CC) $(ZOPFLILIB_SRC) $(ZOPFLIBIN_SRC) $(CFLAGS) -o zopfli
+zopfli: $(ZOPFLIBIN_OBJ) src/zopfli/zopfli_bin.o
+	$(CC) $^ $(LDFLAGS) -o zopfli
 
 # Zopfli shared library
-libzopfli:
-	$(CC) $(ZOPFLILIB_SRC) $(CFLAGS) -fPIC -c
-	$(CC) $(ZOPFLILIB_OBJ) $(CFLAGS) -shared -Wl,-soname,libzopfli.so.1 -o libzopfli.so.1.0.1
+libzopfli: $(ZOPFLILIB_OBJ)
+	$(CC) $(ZOPFLILIB_OBJ) -shared -Wl,-soname,libzopfli.so.1 -o libzopfli.so.1.0.1
 
 # ZopfliPNG binary
-zopflipng:
-	$(CC) $(ZOPFLILIB_SRC) $(CFLAGS) -c
-	$(CXX) $(ZOPFLILIB_OBJ) $(LODEPNG_SRC) $(ZOPFLIPNGLIB_SRC) $(ZOPFLIPNGBIN_SRC) $(CFLAGS) -o zopflipng
+zopflipng: $(ZOPFLIPNGBIN_OBJ) $(ZOPFLIBIN_OBJ) src/zopflipng/zopflipng_bin.o
+	$(CXX) $^ $(LDFLAGS) -o zopflipng
 
 # ZopfliPNG shared library
-libzopflipng:
-	$(CC) $(ZOPFLILIB_SRC) $(CFLAGS) -fPIC -c
-	$(CXX) $(ZOPFLILIB_OBJ) $(LODEPNG_SRC) $(ZOPFLIPNGLIB_SRC) $(CFLAGS) -fPIC --shared -Wl,-soname,libzopflipng.so.1 -o libzopflipng.so.1.0.0
+libzopflipng: $(ZOPFLIPNGLIB_OBJ) $(ZOPFLILIB_OBJ)
+	$(CXX) $(ZOPFLILIB_OBJ) $(ZOPFLIPNGLIB_OBJ) --shared -Wl,-soname,libzopflipng.so.1 -o libzopflipng.so.1.0.0
 
 # Remove all libraries and binaries
 clean:
-	rm -f zopflipng zopfli $(ZOPFLILIB_OBJ) libzopfli*
+	rm -f $(ZOPFLILIB_OBJ) libzopfli*
+	rm -f $(ZOPFLIBIN_OBJ) zopfli
+	rm -f $(ZOPFLIPNGBIN_OBJ) zopflipng
+	rm -f $(ZOPFLIPNGLIB_OBJ)
+
+all: zopfli libzopfli zopflipng libzopflipng


### PR DESCRIPTION
Previously, prerequisites for some targets were implicit in nature, meaning that whether the library targets actually attempted to link with object files compiled with -fPIC depended on the leftover files from previous build and the order in which targets were built.

This could lead to build failures for the libraries, and the standalone utilities may have been able to be linked with object files compiled with position independent code.

Furthermore, a target "all" was added to build all targets, and the phony targets were properly set to "all" and "clean".

This fixes issue #68.
