### PR TITLE
Fix reorder warning

### DIFF
--- a/src/zopflipng/zopflipng_lib.cc
+++ b/src/zopflipng/zopflipng_lib.cc
@@ -31,8 +31,8 @@
 #include "../zopfli/deflate.h"
 
 ZopfliPNGOptions::ZopfliPNGOptions()
-  : lossy_transparent(false)
-  , verbose(false)
+  : verbose(false)
+  , lossy_transparent(false)
   , lossy_8bit(false)
   , auto_filter_strategy(true)
   , use_zopfli(true)


### PR DESCRIPTION
Both gcc and clang complain about this.
```
In file included from src/zopflipng/zopflipng_lib.cc:20:0:
src/zopflipng/zopflipng_lib.h: In constructor 'ZopfliPNGOptions::ZopfliPNGOptions()':
src/zopflipng/zopflipng_lib.h:98:8: warning: 'ZopfliPNGOptions::lossy_transparent' will be initialized after [-Wreorder]
   bool lossy_transparent;
        ^
src/zopflipng/zopflipng_lib.h:95:8: warning:   'bool ZopfliPNGOptions::verbose' [-Wreorder]
   bool verbose;
        ^
src/zopflipng/zopflipng_lib.cc:33:1: warning:   when initialized here [-Wreorder]
 ZopfliPNGOptions::ZopfliPNGOptions()
 ^
```