### PR TITLE
Report errors

### DIFF
--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -43,7 +43,7 @@ Loads a file into a memory array. Returns 1 on success, 0 if file doesn't exist
 or couldn't be opened.
 */
 static int LoadFile(const char* filename,
-                    unsigned char** out, size_t* outsize) {
+                     unsigned char** out, size_t* outsize) {
   FILE* file;
 
   *out = 0;
@@ -188,7 +188,7 @@ int main(int argc, char* argv[]) {
 
   if (options.numiterations < 1) {
     fprintf(stderr, "Error: must have 1 or more iterations\n");
-    return 0;
+    return 1;
   }
 
   for (i = 1; i < argc; i++) {

--- a/src/zopflipng/zopflipng_bin.cc
+++ b/src/zopflipng/zopflipng_bin.cc
@@ -400,5 +400,5 @@ int main(int argc, char *argv[]) {
 
   if (dryrun) printf("No files were written because dry run was specified\n");
 
-  return total_errors;
+  return total_errors > 255 ? 255 : total_errors;
 }

--- a/src/zopflipng/zopflipng_bin.cc
+++ b/src/zopflipng/zopflipng_bin.cc
@@ -134,7 +134,7 @@ void PrintResultSize(const char* label, size_t oldsize, size_t newsize) {
 int main(int argc, char *argv[]) {
   if (argc < 2) {
     ShowHelp();
-    return 0;
+    return 1;
   }
 
   ZopfliPNGOptions png_options;
@@ -168,7 +168,7 @@ int main(int argc, char *argv[]) {
           return 0;
         } else {
           printf("Unknown flag: %c\n", c);
-          return 0;
+          return 1;
         }
       }
     } else if (arg[0] == '-' && arg.size() > 1 && arg[1] == '-') {
@@ -223,7 +223,7 @@ int main(int argc, char *argv[]) {
         if (!correct) {
           printf("Error: keepchunks format must be like for example:\n"
                  " --keepchunks=gAMA,cHRM,sRGB,iCCP\n");
-          return 0;
+          return 1;
         }
       } else if (name == "--prefix") {
         use_prefix = true;
@@ -233,7 +233,7 @@ int main(int argc, char *argv[]) {
         return 0;
       } else {
         printf("Unknown flag: %s\n", name.c_str());
-        return 0;
+        return 1;
       }
     } else {
       files.push_back(argv[i]);
@@ -249,7 +249,7 @@ int main(int argc, char *argv[]) {
     } else {
       printf("Please provide one input and output filename\n\n");
       ShowHelp();
-      return 0;
+      return 1;
     }
   }
 


### PR DESCRIPTION
I've notice the zopfli and zopflipng commands return successful status code to the shell even if no work has been done.
