### PR TITLE
Faster stdout writing

### DIFF
--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -114,14 +114,11 @@ static void CompressFile(const ZopfliOptions* options,
   if (outfilename) {
     SaveFile(outfilename, out, outsize);
   } else {
-    size_t i;
 #if _WIN32
     /* Windows workaround for stdout output. */
     _setmode(_fileno(stdout), _O_BINARY);
 #endif
-    for (i = 0; i < outsize; i++) {
-      printf("%c", out[i]);
-    }
+    fwrite(out, 1, outsize, stdout);
   }
 
   free(out);


### PR DESCRIPTION
I hope `_setmode` makes loop with `printf` unnecessary, so a more efficient writing method can be used.
