### PR TITLE
Fix crash with --prefix

### DIFF
--- a/src/zopflipng/zopflipng_bin.cc
+++ b/src/zopflipng/zopflipng_bin.cc
@@ -356,7 +356,10 @@ int main(int argc, char *argv[]) {
       if (use_prefix) {
         std::string dir, file, ext;
         GetFileNameParts(files[i], &dir, &file, &ext);
-        out_filename = dir + prefix + file + ext;
+        out_filename = dir;
+        out_filename += prefix;
+        out_filename += file;
+        out_filename += ext;
       }
       bool different_output_name = out_filename != files[i];
 


### PR DESCRIPTION
Occurs most likely when certain g++ optimizations are enabled, so this
code needs to be split into parts to make sure we don't run into
false-positive Issue reports when some user tries out some compiler
optimizations.