### PR TITLE
Accept compiler and flags from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-CC = gcc
-CXX = g++
+CC ?= gcc
+CXX ?= g++
 
-CFLAGS = -W -Wall -Wextra -ansi -pedantic -lm -O2 -Wno-unused-function
-CXXFLAGS = -W -Wall -Wextra -ansi -pedantic -O2
+CFLAGS += -W -Wall -Wextra -ansi -pedantic -O2 -Wno-unused-function
+CXXFLAGS += -W -Wall -Wextra -ansi -pedantic -O2
+LDFLAGS += -fPIC
+LIBS += -lm
+
 
 ZOPFLILIB_SRC = src/zopfli/blocksplitter.c src/zopfli/cache.c\
                 src/zopfli/deflate.c src/zopfli/gzip_container.c\
@@ -20,22 +23,22 @@ ZOPFLIPNGBIN_SRC := src/zopflipng/zopflipng_bin.cc
 
 # Zopfli binary
 zopfli:
-	$(CC) $(ZOPFLILIB_SRC) $(ZOPFLIBIN_SRC) $(CFLAGS) -o zopfli
+	$(CC) $(ZOPFLILIB_SRC) $(ZOPFLIBIN_SRC) $(CFLAGS) $(LDFLAGS) -o zopfli $(LIBS)
 
 # Zopfli shared library
 libzopfli:
 	$(CC) $(ZOPFLILIB_SRC) $(CFLAGS) -fPIC -c
-	$(CC) $(ZOPFLILIB_OBJ) $(CFLAGS) -shared -Wl,-soname,libzopfli.so.1 -o libzopfli.so.1.0.1
+	$(CC) $(ZOPFLILIB_OBJ) $(CFLAGS) $(LDFLAGS) -shared -Wl,-soname,libzopfli.so.1 -o libzopfli.so.1.0.1  $(LIBS)
 
 # ZopfliPNG binary
 zopflipng:
 	$(CC) $(ZOPFLILIB_SRC) $(CFLAGS) -c
-	$(CXX) $(ZOPFLILIB_OBJ) $(LODEPNG_SRC) $(ZOPFLIPNGLIB_SRC) $(ZOPFLIPNGBIN_SRC) $(CFLAGS) -o zopflipng
+	$(CXX) $(ZOPFLILIB_OBJ) $(LODEPNG_SRC) $(ZOPFLIPNGLIB_SRC) $(ZOPFLIPNGBIN_SRC) $(CFLAGS) $(LDFLAGS) -o zopflipng $(LIBS)
 
 # ZopfliPNG shared library
 libzopflipng:
 	$(CC) $(ZOPFLILIB_SRC) $(CFLAGS) -fPIC -c
-	$(CXX) $(ZOPFLILIB_OBJ) $(LODEPNG_SRC) $(ZOPFLIPNGLIB_SRC) $(CFLAGS) -fPIC --shared -Wl,-soname,libzopflipng.so.1 -o libzopflipng.so.1.0.0
+	$(CXX) $(ZOPFLILIB_OBJ) $(LODEPNG_SRC) $(ZOPFLIPNGLIB_SRC) $(CFLAGS) $(LDFLAGS)  --shared -Wl,-soname,libzopflipng.so.1 -o libzopflipng.so.1.0.0 $(LIBS)
 
 # Remove all libraries and binaries
 clean:


### PR DESCRIPTION
When packaging for distribution (such as openSUSE), distributions we want to specify CFLAGS/LDFLAGS and in some cases compiler as well.
