### PR TITLE
Speed and compression improvements

### DIFF
--- a/src/zopfli/lz77.c
+++ b/src/zopfli/lz77.c
@@ -263,11 +263,8 @@ Indirectly, this affects:
  to the optimal output
 */
 static int GetLengthScore(int length, int distance) {
-  /*
-  At 1024, the distance uses 9+ extra bits and this seems to be the sweet spot
-  on tested files.
-  */
-  return distance > 1024 ? length - 1 : length;
+  return (length == 3 && distance > 1024) || (length == 4 && distance > 2048) ||
+  (length == 5 && distance > 4096) ? length - 1 : length;
 }
 
 void ZopfliVerifyLenDist(const unsigned char* data, size_t datasize, size_t pos,


### PR DESCRIPTION
This pull request adds some additional improvements from [ECT](https://github.com/fhanau/Efficient-Compression-Tool). The first commit is a follow-up of https://github.com/google/zopfli/pull/111 and makes huffman encoding even faster. The second one improves blocksplitting by only decreasing the lengthscore when the match is short.