### PR TITLE
Fix integer underflow on verbose output

### DIFF
--- a/src/zopfli/deflate.c
+++ b/src/zopfli/deflate.c
@@ -926,6 +926,7 @@ void ZopfliDeflate(const ZopfliOptions* options, int btype, int final,
     fprintf(stderr,
             "Original Size: %lu, Deflate: %lu, Compression: %f%% Removed\n",
             (unsigned long)insize, (unsigned long)(*outsize - offset),
-            100.0 * (double)(insize - (*outsize - offset)) / (double)insize);
+            100.0 * (double)(ssize_t)(insize - (*outsize - offset))
+              / (double)insize);
   }
 }

--- a/src/zopfli/gzip_container.c
+++ b/src/zopfli/gzip_container.c
@@ -119,6 +119,6 @@ void ZopfliGzipCompress(const ZopfliOptions* options,
     fprintf(stderr,
             "Original Size: %d, Gzip: %d, Compression: %f%% Removed\n",
             (int)insize, (int)*outsize,
-            100.0 * (double)(insize - *outsize) / (double)insize);
+            100.0 * (double)(ssize_t)(insize - *outsize) / (double)insize);
   }
 }

--- a/src/zopfli/zlib_container.c
+++ b/src/zopfli/zlib_container.c
@@ -74,6 +74,6 @@ void ZopfliZlibCompress(const ZopfliOptions* options,
     fprintf(stderr,
             "Original Size: %d, Zlib: %d, Compression: %f%% Removed\n",
             (int)insize, (int)*outsize,
-            100.0 * (double)(insize - *outsize) / (double)insize);
+            100.0 * (double)(ssize_t)(insize - *outsize) / (double)insize);
   }
 }


### PR DESCRIPTION
When a compressed file is larger than the original file, the "percent removed" value underflows.

### Before

```bash
$ echo hello > test.txt
$ zopfli -v test.txt
Saving to: test.txt.gz
Iteration 0: 153 bit
compressed block size: 7 (0k) (unc: 6)
Original Size: 6, Deflate: 8, Compression: 307445734561825882112.000000% Removed
Original Size: 6, Gzip: 26, Compression: 307445734561825882112.000000% Removed
$ zopfli --zlib -v test.txt
...
Original Size: 6, Zlib: 14, Compression: 307445734561825882112.000000% Removed
```

### After

```bash
$ zopfli -v test.txt
Saving to: test.txt.gz
Iteration 0: 153 bit
compressed block size: 7 (0k) (unc: 6)
Original Size: 6, Deflate: 8, Compression: -33.333333% Removed
Original Size: 6, Gzip: 26, Compression: -333.333333% Removed
$ zopfli --zlib -v test.txt
...
Original Size: 6, Zlib: 14, Compression: -133.333333% Removed
```