### PR TITLE
Update CMake script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8.11)
 project(Zopfli)
 
 option(BUILD_SHARED_LIBS "Build Zopfli with shared libraries" OFF)
+option(ZOPFLI_BUILD_INSTALL "Add Zopfli install target" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -86,3 +87,18 @@ target_link_libraries(zopfli libzopfli)
 #
 add_executable(zopflipng src/zopflipng/zopflipng_bin.cc)
 target_link_libraries(zopflipng libzopflipng)
+
+#
+# Install
+#
+if(ZOPFLI_BUILD_INSTALL)
+  include(GNUInstallDirs)
+  install(TARGETS libzopfli libzopflipng zopfli zopflipng
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+  install(FILES include/zopfli.h include/zopflipng_lib.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,17 @@ set_target_properties(libzopflipng PROPERTIES
   SOVERSION ${ZOPFLI_VERSION_MAJOR}
 )
 
+# MSVC does not export symbols by default when building a DLL, this is a
+# workaround for recent versions of CMake
+if(MSVC AND ZOPFLI_BUILD_SHARED)
+  if(CMAKE_VERSION VERSION_LESS 3.4)
+    message(WARNING "Automatic export of all symbols to DLL not supported until CMake 3.4")
+  else()
+    set_target_properties(libzopfli PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    set_target_properties(libzopflipng PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  endif()
+endif()
+
 #
 # zopfli
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,33 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project(Zopfli)
 
+# Check if being built standalone
+set(zopfli_standalone FALSE)
+get_directory_property(zopfli_parent_directory PARENT_DIRECTORY)
+if("${zopfli_parent_directory}" STREQUAL "")
+  set(zopfli_standalone TRUE)
+endif()
+unset(zopfli_parent_directory)
+
+#
+# Options
+#
+
+# Default to BUILD_SHARED_LIBS if set, but allow overriding it
+set(zopfli_shared_default OFF)
+if(DEFINED BUILD_SHARED_LIBS)
+  set(zopfli_shared_default ${BUILD_SHARED_LIBS})
+endif()
+option(ZOPFLI_BUILD_SHARED "Build Zopfli with shared libraries" ${zopfli_shared_default})
+unset(zopfli_shared_default)
+
+# If standalone or shared subproject, default to building install
+if(zopfli_standalone OR ZOPFLI_BUILD_SHARED)
+  option(ZOPFLI_BUILD_INSTALL "Add Zopfli install target" ON)
+else()
+  option(ZOPFLI_BUILD_INSTALL "Add Zopfli install target" OFF)
+endif()
+
 #
 # Library version
 #
@@ -10,13 +37,16 @@ set(ZOPFLI_VERSION_MINOR 0)
 set(ZOPFLI_VERSION_PATCH 2)
 set(ZOPFLI_VERSION "${ZOPFLI_VERSION_MAJOR}.${ZOPFLI_VERSION_MINOR}.${ZOPFLI_VERSION_PATCH}")
 
-option(BUILD_SHARED_LIBS "Build Zopfli with shared libraries" OFF)
-option(ZOPFLI_BUILD_INSTALL "Add Zopfli install target" ON)
-
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+if(zopfli_standalone)
   if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "Zopfli build type is default (CMAKE_BUILD_TYPE empty)")
   endif()
+endif()
+
+if(ZOPFLI_BUILD_SHARED)
+  set(zopfli_library_type SHARED)
+else()
+  set(zopfli_library_type STATIC)
 endif()
 
 set(zopflilib_src
@@ -49,14 +79,14 @@ set (lodepng_src
 add_library(zopflilib_obj OBJECT
   ${zopflilib_src}
 )
-if(BUILD_SHARED_LIBS)
+if(ZOPFLI_BUILD_SHARED)
   set_property(TARGET zopflilib_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
 #
 # libzopfli
 #
-add_library(libzopfli
+add_library(libzopfli ${zopfli_library_type}
   $<TARGET_OBJECTS:zopflilib_obj>
 )
 target_include_directories(libzopfli INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src/zopfli")
@@ -72,7 +102,7 @@ endif()
 #
 # libzopflipng
 #
-add_library(libzopflipng
+add_library(libzopflipng ${zopfli_library_type}
   ${zopflipnglib_src}
   ${lodepng_src}
   $<TARGET_OBJECTS:zopflilib_obj>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,6 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
   endif()
 endif()
 
-if(MSVC)
-  add_definitions(/D_CRT_SECURE_NO_WARNINGS)
-endif()
-
 set(zopflilib_src
   src/zopfli/blocksplitter.c
   src/zopfli/cache.c
@@ -93,12 +89,18 @@ set_target_properties(libzopflipng PROPERTIES
 #
 add_executable(zopfli src/zopfli/zopfli_bin.c)
 target_link_libraries(zopfli libzopfli)
+if(MSVC)
+  target_compile_definitions(zopfli PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
 
 #
 # zopflipng
 #
 add_executable(zopflipng src/zopflipng/zopflipng_bin.cc)
 target_link_libraries(zopflipng libzopflipng)
+if(MSVC)
+  target_compile_definitions(zopflipng PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
 
 #
 # Install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,10 @@ set(ZOPFLI_VERSION "${ZOPFLI_VERSION_MAJOR}.${ZOPFLI_VERSION_MINOR}.${ZOPFLI_VER
 option(BUILD_SHARED_LIBS "Build Zopfli with shared libraries" OFF)
 option(ZOPFLI_BUILD_INSTALL "Add Zopfli install target" ON)
 
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Zopfli build type is default (CMAKE_BUILD_TYPE empty)")
+  endif()
 endif()
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project(Zopfli)
 
+#
+# Library version
+#
+set(ZOPFLI_VERSION_MAJOR 1)
+set(ZOPFLI_VERSION_MINOR 0)
+set(ZOPFLI_VERSION_PATCH 2)
+set(ZOPFLI_VERSION "${ZOPFLI_VERSION_MAJOR}.${ZOPFLI_VERSION_MINOR}.${ZOPFLI_VERSION_PATCH}")
+
 option(BUILD_SHARED_LIBS "Build Zopfli with shared libraries" OFF)
 option(ZOPFLI_BUILD_INSTALL "Add Zopfli install target" ON)
 
@@ -55,8 +63,8 @@ add_library(libzopfli
 )
 set_target_properties(libzopfli PROPERTIES
   OUTPUT_NAME zopfli
-  VERSION 1.0.2
-  SOVERSION 1
+  VERSION ${ZOPFLI_VERSION}
+  SOVERSION ${ZOPFLI_VERSION_MAJOR}
 )
 if(UNIX)
   target_link_libraries(libzopfli m)
@@ -72,8 +80,8 @@ add_library(libzopflipng
 )
 set_target_properties(libzopflipng PROPERTIES
   OUTPUT_NAME zopflipng
-  VERSION 1.0.2
-  SOVERSION 1
+  VERSION ${ZOPFLI_VERSION}
+  SOVERSION ${ZOPFLI_VERSION_MAJOR}
 )
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ endif()
 add_library(libzopfli
   $<TARGET_OBJECTS:zopflilib_obj>
 )
+target_include_directories(libzopfli INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src/zopfli")
 set_target_properties(libzopfli PROPERTIES
   OUTPUT_NAME zopfli
   VERSION ${ZOPFLI_VERSION}
@@ -78,6 +79,7 @@ add_library(libzopflipng
   ${lodepng_src}
   $<TARGET_OBJECTS:zopflilib_obj>
 )
+target_include_directories(libzopflipng INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src/zopflipng")
 set_target_properties(libzopflipng PROPERTIES
   OUTPUT_NAME zopflipng
   VERSION ${ZOPFLI_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.11)
 
 project(Zopfli)
 
@@ -11,7 +11,7 @@ endif()
 if(MSVC)
   add_definitions(/D_CRT_SECURE_NO_WARNINGS)
 endif()
- 
+
 set(zopflilib_src
   src/zopfli/blocksplitter.c
   src/zopfli/cache.c


### PR DESCRIPTION
Okay, as mentioned in #143 I've taken a shot at updating the CMake script to try to address some of the issues raised there. Specifically:

  - Add install target
  - Version is only set once
  - The default build type now uses CFLAGS etc.

I also improved support for using Zopfli as a subproject from other CMake based projects.

Some issues/things to discuss that remain:

  - I added a workaround for the issue about symbol export when building as a DLL with MSVC, it only works for recent versions of CMake. Actually fixing this would require adding macros to the public headers to optionally export symbols, and I don't know if the devs are interested in this (see for instance [this description](https://gcc.gnu.org/wiki/Visibility)).
  - libm is still included by default on UNIX, somebody with more knowledge about this will have to fix it if needed.
  - Leaving the default build type alone allows building using CFLAGS etc., but means the default build will be unoptimized, perhaps the docs should suggest building with -DCMAKE_BUILD_TYPE=Release?