### PR TITLE
Enable automatic zopflipng Windows builds with AppVeyor

### DIFF
--- a/README-zopflipng.md
+++ b/README-zopflipng.md
@@ -1,3 +1,6 @@
+[![AppVeyor Build Status](https://ci.appveyor.com/project/google/zopfli/branch/master?svg=true)](https://ci.appveyor.com/project/google/zopfli)
+
+## ZopfliPNG ## 
 ZopfliPNG is a command line program to optimize the Portable Network Graphics
 (PNG) images. This version has the following features:
 - uses Zopfli compression for the Deflate compression,
@@ -12,27 +15,31 @@ ZopfliPNG is a command line program to optimize the Portable Network Graphics
 This is an alpha-release for testing while improvements, particularly to add
 palette selection, are still being made. Feedback and bug reports are welcome.
 
-Important:
+### Important ###
 
 This PNG optimizer removes ancillary chunks (pieces of metadata) from the
 PNG image that normally do not affect rendering. However in special
 circumstances you may wish to keep some. For example for a design using
 custom gamma correction, keeping it may be desired. Visually check in the
-target renderer after using ZopfliPNG. Use --keepchunks to keep chunks, e.g.
---keepchunks=gAMA,pHYs to keep gamma and DPI information. This will increase
+target renderer after using ZopfliPNG. Use `--keepchunks` to keep chunks, e.g.
+`--keepchunks=gAMA,pHYs` to keep gamma and DPI information. This will increase
 file size. The following page contains a list of ancillary PNG chunks:
 http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html
 
-Build instructions:
+### Build instructions ###
 
 To build ZopfliPNG, compile all .c, .cc and .cpp files from src/zopfli,
 src/zopflipng and src/zopflipng/lodepng, except src/zopfli/zopfli_bin.c, to a
 single binary with C++, e.g.:
-g++ src/zopfli/{blocksplitter,cache,deflate,gzip_container,hash,katajainen,lz77,squeeze,tree,util,zlib_container,zopfli_lib}.c src/zopflipng/*.cc src/zopflipng/lodepng/*.cpp -O2 -W -Wall -Wextra -Wno-unused-function -ansi -pedantic -o zopflipng
+`g++ src/zopfli/{blocksplitter,cache,deflate,gzip_container,hash,katajainen,lz77,squeeze,tree,util,zlib_container,zopfli_lib}.c src/zopflipng/*.cc src/zopflipng/lodepng/*.cpp -O2 -W -Wall -Wextra -Wno-unused-function -ansi -pedantic -o zopflipng`
 
 A makefile is provided as well, but only for linux: use "make zopflipng" with
 the Zopfli makefile. For other platforms, please use the build instructions
 above instead.
+
+Automatic build for Windows x86-64 are available on [AppVeyor](https://ci.appveyor.com/project/google/zopfli).
+
+### Compression algorithm ###
 
 The main compression algorithm in ZopfliPNG is ported from WebP lossless, but
 naturally cannot give as much compression gain for PNGs as it does for a more

--- a/README-zopflipng.md
+++ b/README-zopflipng.md
@@ -1,4 +1,4 @@
-[![AppVeyor Build Status](https://ci.appveyor.com/project/google/zopfli/branch/master?svg=true)](https://ci.appveyor.com/project/google/zopfli)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/google/zopfli?branch=master&svg=true)](https://ci.appveyor.com/project/google/zopfli)
 
 ## ZopfliPNG ## 
 ZopfliPNG is a command line program to optimize the Portable Network Graphics

--- a/README-zopflipng.md
+++ b/README-zopflipng.md
@@ -1,6 +1,4 @@
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/google/zopfli?branch=master&svg=true)](https://ci.appveyor.com/project/google/zopfli)
-
-## ZopfliPNG ## 
+## ZopfliPNG ## [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/google/zopfli?branch=master&svg=true)](https://ci.appveyor.com/project/google/zopfli)
 ZopfliPNG is a command line program to optimize the Portable Network Graphics
 (PNG) images. This version has the following features:
 - uses Zopfli compression for the Deflate compression,

--- a/README-zopflipng.md
+++ b/README-zopflipng.md
@@ -1,4 +1,4 @@
-## ZopfliPNG ## [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/google/zopfli?branch=master&svg=true)](https://ci.appveyor.com/project/google/zopfli)
+## ZopfliPNG [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/google/zopfli?branch=master&svg=true)](https://ci.appveyor.com/project/google/zopfli)
 ZopfliPNG is a command line program to optimize the Portable Network Graphics
 (PNG) images. This version has the following features:
 - uses Zopfli compression for the Deflate compression,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+image: Visual Studio 2017
+
+install:
+ - SET PATH=C:\cygwin64\bin;%PATH%
+
+build_script:
+ - x86_64-pc-cygwin-g++.exe src/zopfli/{blocksplitter,cache,deflate,gzip_container,hash,katajainen,lz77,squeeze,tree,util,zlib_container,zopfli_lib}.c src/zopflipng/*.cc src/zopflipng/lodepng/*.cpp -O2 -W -Wall -Wextra -Wno-unused-function -ansi -pedantic -o zopflipng
+ 
+artifacts:
+ - path: \**\zopflipng.exe
+   name: zopflipng

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,27 @@
 image: Visual Studio 2017
+configuration: Release
 
-install:
- - SET PATH=C:\cygwin64\bin;%PATH%
+## Sets up two jobs, one with cmake (MSVC) and one with cygwin64
+environment:
+  matrix:
+   - compiler: cmake
+     instal-script: 'cd %APPVEYOR_BUILD_FOLDER% & mkdir cmake_build & cd cmake_build & cmake --version & cmake c:\projects\zopfli'
+   - compiler: cygwin64
+     instal-script: 'SET PATH=C:\cygwin64\bin;%PATH%'
 
+## Installs 'instal-script' from matrix
+before_build:
+- cmd: |-
+    %instal-script%
+
+## Builds zopflipng
 build_script:
- - x86_64-pc-cygwin-g++.exe src/zopfli/{blocksplitter,cache,deflate,gzip_container,hash,katajainen,lz77,squeeze,tree,util,zlib_container,zopfli_lib}.c src/zopflipng/*.cc src/zopflipng/lodepng/*.cpp -O2 -W -Wall -Wextra -Wno-unused-function -ansi -pedantic -o zopflipng
+ - IF "%compiler%"=="cmake" msbuild "C:\projects\zopfli\cmake_build\zopfli.sln"
+ - IF "%compiler%"=="cygwin64" x86_64-pc-cygwin-g++.exe src/zopfli/{blocksplitter,cache,deflate,gzip_container,hash,katajainen,lz77,squeeze,tree,util,zlib_container,zopfli_lib}.c src/zopflipng/*.cc src/zopflipng/lodepng/*.cpp -O2 -W -Wall -Wextra -Wno-unused-function -ansi -pedantic -o zopflipng
  
+## Publishes artifacts to AppVeyor
 artifacts:
- - path: \**\zopflipng.exe
-   name: zopflipng
+ - path: cmake_build\Release\zopflipng.exe
+   name: zopflip-x86_64-cmake
+ - path: zopflipng.exe
+   name: zopflipng-x86_64-cygwin64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 
 ## Sets up two jobs, one with cmake (MSVC) and one with cygwin64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ configuration: Release
 environment:
   matrix:
    - compiler: cmake
-     instal-script: 'cd %APPVEYOR_BUILD_FOLDER% & mkdir cmake_build & cd cmake_build & cmake --version & cmake c:\projects\zopfli'
+     instal-script: 'cd %APPVEYOR_BUILD_FOLDER% & mkdir cmake_build & cd cmake_build & cmake --version & cmake -A x64 c:\projects\zopfli'
    - compiler: cygwin64
      instal-script: 'SET PATH=C:\cygwin64\bin;%PATH%'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 
 ## Sets up two jobs, one with cmake (MSVC) and one with cygwin64


### PR DESCRIPTION
Enables automatic builds of ZopfliPNG for x86-64 Windows.

AppVeyor only needs to be enabled on https://ci.appveyor.com/project/google/zopfli