### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.zopflipng
+++ b/README.zopflipng
@@ -52,3 +52,16 @@ suitable plugins for other browsers, it is good to note that WebP lossless
 images are still 26 % smaller than images recompressed with ZopfliPNG.
 
 2013-05-07, Lode Vandevenne and Jyrki Alakuijala
+
+Building zopfli - Using vcpkg
+
+The url of vcpkg is: https://github.com/Microsoft/vcpkg
+You can download and install zopfli using the vcpkg dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install zopfli
+
+The zopfli port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request on the vcpkg repository.


### PR DESCRIPTION
Zopfli is available as a port in vcpkg, a C++ library manager that simplifies installation for zopfli and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build zopfli, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.