### PR TITLE
Fix the i686-linux-android build.

### DIFF
--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -34,7 +34,7 @@ void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
   if(lmc->sublen == NULL) {
     fprintf(stderr,
         "Error: Out of memory. Tried allocating %lu bytes of memory.\n",
-        ZOPFLI_CACHE_LENGTH * 3 * blocksize);
+        (unsigned long)ZOPFLI_CACHE_LENGTH * 3 * blocksize);
     exit (EXIT_FAILURE);
   }
 


### PR DESCRIPTION
Found while trying to update AOSP's copy of zopfli from circa-2015
source:

external/zopfli/src/zopfli/cache.c:37:9: error: format specifies type
'unsigned long' but the argument has type 'unsigned int'
[-Werror,-Wformat]
        ZOPFLI_CACHE_LENGTH * 3 * blocksize);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~