### PR TITLE
Bazel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bazel-bin
+bazel-out
+bazel-testlogs
+bazel-zopfli

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,41 @@
+# Description:
+#   Zopfli is a zlib- and deflate-compatible compression algorithm.
+#   Zopfli prefers compression ratio over compression speed.
+
+STRICT_C_OPTIONS = [
+    "-O3",
+    "-W",
+    "-Wall",
+    "-Wextra",
+    "-Wno-unused-function",
+    "-ansi",
+    "-fPIC",
+    "-pedantic",
+]
+
+cc_binary(
+    name = "zopfli",
+    srcs = glob([
+        "src/zopfli/*.c",
+        "src/zopfli/*.h",
+    ]),
+    copts = STRICT_C_OPTIONS,
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "zopflipng",
+    srcs = glob(
+        [
+            "src/zopflipng/*.cc",
+            "src/zopflipng/*.h",
+            "src/zopfli/*.c",
+            "src/zopfli/*.h",
+            "src/zopflipng/lodepng/*.cpp",
+            "src/zopflipng/lodepng/*.h",
+        ],
+        exclude = ["src/zopfli/zopfli_bin.c"],
+    ),
+    copts = STRICT_C_OPTIONS,
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This adds two public targets:

- `:zopfli`.
- `:zopflipng`.

Which enable easily adding Zopfli in bazel-enabled repositories:

1. Add this repo through `http_archive`.
2. use `@zopfli//:zopfli`. My use case is to zopfli some CSS at build time:
```
genrule(
    name = "all-min.css_gz",
    srcs = ["gen/all-min.css"],
    outs = ["all-min.css.gz"],
    cmd = "$(location @zopfli//:zopfli) -c $< > $@",
    tools = ["@zopfli"],
)
```

Everything is compiled statically (i.e. zopflipng statically links zopfli) for the sake of simplicity.