### PR TITLE
Fix compilation on MSVC 2008

### DIFF
--- a/src/zopfli/tree.c
+++ b/src/zopfli/tree.c
@@ -76,13 +76,13 @@ void ZopfliCalculateEntropy(const size_t* count, size_t n, double* bitlengths) {
   for (i = 0; i < n; ++i) {
     sum += count[i];
   }
-  log2sum = (sum == 0 ? log(n) : log(sum)) * kInvLog2;
+  log2sum = (sum == 0 ? log((double)n) : log((double)sum)) * kInvLog2;
   for (i = 0; i < n; ++i) {
     /* When the count of the symbol is 0, but its cost is requested anyway, it
     means the symbol will appear at least once anyway, so give it the cost as if
     its count is 1.*/
     if (count[i] == 0) bitlengths[i] = log2sum;
-    else bitlengths[i] = log2sum - log(count[i]) * kInvLog2;
+    else bitlengths[i] = log2sum - log((double)count[i]) * kInvLog2;
     /* Depending on compiler and architecture, the above subtraction of two
     floating point numbers may give a negative result very close to zero
     instead of zero (e.g. -5.973954e-17 with gcc 4.1.2 on Ubuntu 11.4). Clamp

--- a/src/zopfli/util.h
+++ b/src/zopfli/util.h
@@ -62,7 +62,7 @@ Set it to 0 to disable master blocks.
 /*
 Used to initialize costs for example
 */
-#define ZOPFLI_LARGE_FLOAT 1e30
+#define ZOPFLI_LARGE_FLOAT 1e30f
 
 /*
 For longest match cache. max 256. Uses huge amounts of memory but makes it

--- a/src/zopfli/zopfli_bin.c
+++ b/src/zopfli/zopfli_bin.c
@@ -35,6 +35,7 @@ decompressor.
 
 /* Windows workaround for stdout output. */
 #if _WIN32
+#include <io.h>	
 #include <fcntl.h>
 #endif
 


### PR DESCRIPTION
Misc. linting to get this building on my machine - an undefined function (found in io.h) and some casts required to avoid warnings or ambiguous statements when compiling in C++ mode.

I use a SOURCES file plus WinDDK 7.1 to build this for Windows XP machines, and these allow building to succeed with warning level up to /W2.