### PR TITLE
 Multiplication result converted to larger type

### DIFF
--- a/src/zopflipng/lodepng/lodepng_util.cpp
+++ b/src/zopflipng/lodepng/lodepng_util.cpp
@@ -1151,7 +1151,7 @@ unsigned convertToXYZ(float* out, float whitepoint[3], const unsigned char* in,
     use_icc = validateICC(&icc);
   }
 
-  data = (unsigned char*)lodepng_malloc(w * h * (bit16 ? 8 : 4));
+  data = (unsigned char*)lodepng_malloc((size_t)w * h * (bit16 ? 8 : 4));
   error = lodepng_convert(data, in, &tempmode, mode_in, w, h);
   if(error) goto cleanup;
 


### PR DESCRIPTION
To address the potential overflow issue in the multiplication of w * h * (bit16 ? 8 : 4) and casting it to size_t, I had perform the multiplication using size_t directly to avoid the overflow.
patch link: https://issuetracker.google.com/issues/322327444

Code modification ensures that the multiplication is done using the larger integer type (size_t) before casting the result to unsigned char*. Using size_t for the multiplication helps prevent overflow issues, as size_t is typically large enough to accommodate the size of memory in the system.