### PR TITLE
 Multiplication result converted to larger type (Mitigate Arithmetic Overflow in Memory Allocation)

### DIFF
--- a/src/zopflipng/lodepng/lodepng_util.cpp
+++ b/src/zopflipng/lodepng/lodepng_util.cpp
@@ -1151,7 +1151,7 @@ unsigned convertToXYZ(float* out, float whitepoint[3], const unsigned char* in,
     use_icc = validateICC(&icc);
   }
 
-  data = (unsigned char*)lodepng_malloc(w * h * (bit16 ? 8 : 4));
+  data = (unsigned char*)lodepng_malloc((size_t)w * (size_t)h * (bit16 ? 8 : 4));
   error = lodepng_convert(data, in, &tempmode, mode_in, w, h);
   if(error) goto cleanup;
 


### PR DESCRIPTION

In This PR a potential vulnerability related to arithmetic overflow in the `lodepng_malloc` call. The multiplication of `w * h * (bit16 ? 8 : 4)` might result in overflow before the conversion to `size_t`, leading to unexpected behavior or security risks.

Modified the code to ensure safe multiplication by explicitly casting `w` and `h` to `size_t` before performing the arithmetic operation.

The explicit casting to `size_t` helps prevent arithmetic overflow by ensuring that the multiplication is performed using a larger integer type, reducing the risk of unexpected behavior or security vulnerabilities, especially in memory allocation scenarios.

Exact Security Issue: Arithmetic overflow can lead to allocating less memory than required, which can cause buffer overflows when the memory is accessed. Buffer overflows are well-known security vulnerabilities that can be exploited to execute arbitrary code, cause a program to crash, or lead to other undefined behavior.
