### PR TITLE
Fix printf compiler warning

### DIFF
--- a/src/zopfli/cache.c
+++ b/src/zopfli/cache.c
@@ -33,8 +33,8 @@ void ZopfliInitCache(size_t blocksize, ZopfliLongestMatchCache* lmc) {
   lmc->sublen = (unsigned char*)malloc(ZOPFLI_CACHE_LENGTH * 3 * blocksize);
   if(lmc->sublen == NULL) {
     fprintf(stderr,
-        "Error: Out of memory. Tried allocating %lu bytes of memory.\n",
-        (unsigned long)ZOPFLI_CACHE_LENGTH * 3 * blocksize);
+        "Error: Out of memory. Tried allocating %zu bytes of memory.\n",
+        ZOPFLI_CACHE_LENGTH * 3 * blocksize);
     exit (EXIT_FAILURE);
   }
 


### PR DESCRIPTION
An incorrect format specifier is used in cache.c (%lu instead of %zu for size_t) causing a compiler warning in Clang:
```
C:/Users/RFL890/zopfli/src/zopfli/cache.c:37:9: warning: format specifies type 'unsigned long' but the argument has type 'size_t' (aka 'unsigned long long') [-Wformat]
   36 |         "Error: Out of memory. Tried allocating %lu bytes of memory.\n",
      |                                                 ~~~
      |                                                 %zu
   37 |         (unsigned long)ZOPFLI_CACHE_LENGTH * 3 * blocksize);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
This PR fixes it by using the correct format specifier