### PR TITLE
CMake: install more headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,12 @@ if(ZOPFLI_BUILD_INSTALL)
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
-  install(FILES src/zopfli/zopfli.h src/zopflipng/zopflipng_lib.h
+  install(FILES
+  		src/zopfli/deflate.h
+  		src/zopfli/gzip_container.h
+  		src/zopfli/zlib_container.h
+  		src/zopfli/zopfli.h
+  		src/zopflipng/zopflipng_lib.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   )
 


### PR DESCRIPTION
These headers are even explicitly listed in README, so I don't see why wouldn't they be installed.