### PR TITLE
Support keep_colortype in C API

### DIFF
--- a/src/zopflipng/zopflipng_lib.cc
+++ b/src/zopflipng/zopflipng_lib.cc
@@ -475,6 +475,7 @@ extern "C" void CZopfliPNGSetDefaults(CZopfliPNGOptions* png_options) {
   png_options->lossy_transparent    = opts.lossy_transparent;
   png_options->lossy_8bit           = opts.lossy_8bit;
   png_options->auto_filter_strategy = opts.auto_filter_strategy;
+  png_options->keep_colortype       = opts.keep_colortype;
   png_options->use_zopfli           = opts.use_zopfli;
   png_options->num_iterations       = opts.num_iterations;
   png_options->num_iterations_large = opts.num_iterations_large;
@@ -493,6 +494,7 @@ extern "C" int CZopfliPNGOptimize(const unsigned char* origpng,
   opts.lossy_transparent    = !!png_options->lossy_transparent;
   opts.lossy_8bit           = !!png_options->lossy_8bit;
   opts.auto_filter_strategy = !!png_options->auto_filter_strategy;
+  opts.keep_colortype       = !!png_options->keep_colortype;
   opts.use_zopfli           = !!png_options->use_zopfli;
   opts.num_iterations       = png_options->num_iterations;
   opts.num_iterations_large = png_options->num_iterations_large;

--- a/src/zopflipng/zopflipng_lib.h
+++ b/src/zopflipng/zopflipng_lib.h
@@ -56,6 +56,8 @@ typedef struct CZopfliPNGOptions {
 
   int auto_filter_strategy;
 
+  int keep_colortype;
+
   char** keepchunks;
   // How many entries in keepchunks.
   int num_keepchunks;


### PR DESCRIPTION
The commad-line tool, zopflipng supports "--keepcolortype" (7113f4e96bd26df27c46d590df95e517b966f10d), but the library does not.
Add `keep_colortype` to `CZopfliPNGOptions` in this Pull-Request.