### PR TITLE
Fixed/removed warning when runing on newer cmake systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.5)
 
 project(Zopfli)
 


### PR DESCRIPTION
Now min is 3.5 not 2.x